### PR TITLE
Enhancement: Use appropriate words

### DIFF
--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -625,7 +625,7 @@ export const en = {
     'authz.apikey_not_active': 'API Key state is \'inactive',
     'authz.disabled_2fa': 'API Key owner has disabled 2FA',
     'authz.invalid_api_key_headers': 'Blank or missing API Key headers',
-    'authz.permission_denied': 'Path is blacklisted',
+    'authz.permission_denied': 'Path is denylisted',
     'authz.unexistent_apikey': 'X-Auth-Apikey header is invalid',
     'authz.client_session_mismatch': 'Session mismatch',
     'authz.csrf_token_mismatch': 'CSRF token mismatch',


### PR DESCRIPTION
The technology industry has started to replace problematic racist terminology with more appropriate and precise. It's time to shift from naming conventions, which cause misunderstanding.

### [Google](https://developers.google.com/style/word-list)
> Avoid blacklist and whitelist. Instead, use more precise terms that are appropriate to your domain, such as denylist/allowlist or blocklist/allowlist.
### [IBM](https://cloud.ibm.com/docs/overview?topic=overview-glossary)
> allowlist
> A list of items, such as usernames, email addresses, or IP addresses, that are granted access to a certain system or function. When an allowlist is used for access control, all entities are denied access, except for those that are included in the allowlist. See also blocklist.
> blocklist
> A list of items, such as usernames, email addresses, or IP addresses, that are denied access to a certain system or function. When a blocklist is used for access control, all entities are allowed access, except for those that are included in the blocklist. See also allowlist.