### PR TITLE
Fix: remove scroll from disable deposit screen

### DIFF
--- a/src/mobile/styles/components/WalletDepositBody.pcss
+++ b/src/mobile/styles/components/WalletDepositBody.pcss
@@ -1,5 +1,6 @@
 /* stylelint-disable */
 .cr-mobile-wallet-deposit-body {
+  position: relative;
   .cr-wallet-item__single {
     display: none;
   }
@@ -62,5 +63,9 @@
     &__title {
       color: var(--primary-text-color);
     }
+  }
+
+  .pg-blur-deposit-fiat {
+    overflow: hidden;
   }
 }


### PR DESCRIPTION
Removed unused scroll on blurred screen, so that blur fits 100% height