### PR TITLE
Fix: set generated address to Redux from ws

### DIFF
--- a/mocks/ranger.js
+++ b/mocks/ranger.js
@@ -156,8 +156,7 @@ const matchedTradesMock = (ws, marketId) => {
             "date": at,
             "taker_type": takerType,
             "price": price,
-            "amount": volume,
-            "total": (volume * price).toFixed(4)
+            "amount": volume
         };
 
         if (ws.authenticated && shouldPushOrder) {

--- a/src/modules/public/ranger/sagas/rangerSaga.test.ts
+++ b/src/modules/public/ranger/sagas/rangerSaga.test.ts
@@ -515,7 +515,6 @@ describe('Ranger module', () => {
                 date: 1547464388,
                 price: '0.0002',
                 amount: '0.00015',
-                total: '0.00000003',
             };
             const mockTrades = {
                 trades: [tradeEvent],

--- a/src/modules/public/recentTrades/reducer.test.ts
+++ b/src/modules/public/recentTrades/reducer.test.ts
@@ -56,6 +56,25 @@ describe('recentTrade reducer', () => {
         },
     ];
 
+    const fakeTradesAdjusted: PublicTrade[] = [
+        {
+            id: 162413,
+            price: '0.01',
+            amount: '0.059',
+            market: 'bchbtc',
+            created_at: '2019-01-14T11:13:08.000Z',
+            taker_type: 'sell',
+        },
+        {
+            id: 162414,
+            price: '0.01',
+            amount: '0.01',
+            market: 'bchbtc',
+            created_at: '2019-01-14T11:13:08.000Z',
+            taker_type: 'buy',
+        },
+    ];
+
     const trade: PublicTrade = {
         id: 162413,
         price: '0.01',
@@ -127,7 +146,7 @@ describe('recentTrade reducer', () => {
         };
         expect(recentTradesReducer(initialState, recentTradesPush({ trades: fakeTradeEvents, market: 'bchbtc' }))).toEqual({
             loading: false,
-            list: fakeTrades.concat(trade),
+            list: fakeTradesAdjusted.concat(trade),
         });
     });
 
@@ -154,7 +173,7 @@ describe('recentTrade reducer', () => {
         Cryptobase.config.storage.defaultStorageLimit = 2;
         expect(recentTradesReducer(initialState, recentTradesPush({ trades: fakeTradeEvents, market: 'bchbtc' }))).toEqual({
             loading: false,
-            list: fakeTrades,
+            list: fakeTradesAdjusted,
         });
         Cryptobase.config.storage.defaultStorageLimit = initialLimit;
 

--- a/src/modules/public/recentTrades/reducer.test.ts
+++ b/src/modules/public/recentTrades/reducer.test.ts
@@ -46,7 +46,6 @@ describe('recentTrade reducer', () => {
             date: 1547464388,
             price: '0.01',
             amount: '0.059',
-            total: '0.00059',
         },
         {
             tid: 162414,
@@ -54,7 +53,6 @@ describe('recentTrade reducer', () => {
             date: 1547464388,
             price: '0.01',
             amount: '0.01',
-            total: '0.0001',
         },
     ];
 

--- a/src/modules/public/recentTrades/reducer.ts
+++ b/src/modules/public/recentTrades/reducer.ts
@@ -24,7 +24,7 @@ export const convertTradeEventToTrade = (market: string, trade: PublicTradeEvent
     taker_type: trade.taker_type,
     price: String(trade.price),
     amount: String(trade.amount),
-    total: trade.total && String(trade.total),
+    total: String(+trade.amount * +trade.price),
 });
 
 export const convertTradeEventList = (market: string, trades: PublicTradeEvent[]): PublicTrade[] =>

--- a/src/modules/public/recentTrades/reducer.ts
+++ b/src/modules/public/recentTrades/reducer.ts
@@ -24,7 +24,6 @@ export const convertTradeEventToTrade = (market: string, trade: PublicTradeEvent
     taker_type: trade.taker_type,
     price: String(trade.price),
     amount: String(trade.amount),
-    total: String(+trade.amount * +trade.price),
 });
 
 export const convertTradeEventList = (market: string, trades: PublicTradeEvent[]): PublicTrade[] =>

--- a/src/modules/public/recentTrades/reducer.ts
+++ b/src/modules/public/recentTrades/reducer.ts
@@ -24,7 +24,7 @@ export const convertTradeEventToTrade = (market: string, trade: PublicTradeEvent
     taker_type: trade.taker_type,
     price: String(trade.price),
     amount: String(trade.amount),
-    total: String(trade.total),
+    total: trade.total && String(trade.total),
 });
 
 export const convertTradeEventList = (market: string, trades: PublicTradeEvent[]): PublicTrade[] =>

--- a/src/modules/public/recentTrades/types.ts
+++ b/src/modules/public/recentTrades/types.ts
@@ -4,5 +4,4 @@ export interface PublicTradeEvent {
     date: number;
     price: string;
     amount: string;
-    total: string;
 }

--- a/src/modules/user/history/types.ts
+++ b/src/modules/user/history/types.ts
@@ -3,7 +3,7 @@ import { CommonState } from '../../types';
 export interface PublicTrade {
     id: number;
     price: string;
-    total: string;
+    total?: string;
     amount: string;
     market: string;
     created_at: string;

--- a/src/screens/WalletsScreen/index.tsx
+++ b/src/screens/WalletsScreen/index.tsx
@@ -340,7 +340,6 @@ class WalletsComponent extends React.Component<Props, WalletsState> {
 
         if (!wallet.deposit_address && wallets.length && wallet.type !== 'fiat') {
             this.props.fetchAddress({ currency: wallets[selectedWalletIndex].currency });
-            this.props.fetchWallets();
         }
     };
 


### PR DESCRIPTION
API call to peatio account addresses is overriding data that comes form WS.
Also fix for trades event, total value can be missing, so prevent converting undefined to string