### PR TITLE
Fix: solve translations overwriting issue

### DIFF
--- a/src/custom/translations/index.ts
+++ b/src/custom/translations/index.ts
@@ -1,13 +1,4 @@
-import { en } from '../../translations/en';
 import { ru } from './ru';
-
-// tslint:disable:no-submodule-imports
-// import localeRu from 'react-intl/locale-data/ru';
-// tslint:enable
-
-// export const customLocaleData = ([...localeRu]);
-
-export type LangType = typeof en;
 
 export const customLanguageMap = {
     ru,

--- a/src/custom/translations/ru.ts
+++ b/src/custom/translations/ru.ts
@@ -1,4 +1,3 @@
-import { ru as mobileTranslationsRu } from '../../mobile/translations';
 import { LangType } from '../../translations';
 import { nationalitiesNames } from '../../translations/nationalities';
 
@@ -926,5 +925,4 @@ export const ru: LangType = {
     'metamask.error.unknown': '[MetaMask] Произошла неизвестная ошибка. Проверьте консоль для получения дополнительных сведений',
 
     ...nationalitiesNames,
-    ...mobileTranslationsRu,
 };

--- a/src/translations/en.ts
+++ b/src/translations/en.ts
@@ -1,5 +1,3 @@
-import { en as customTranslations } from '../custom/translations/en';
-import { en as mobileTranslations } from '../mobile/translations/en';
 import { nationalitiesNames } from './nationalities';
 
 export const en = {
@@ -923,6 +921,4 @@ export const en = {
     'metamask.error.unknown': '[MetaMask] An unknown error occurred. Check the console for more details',
 
     ...nationalitiesNames,
-    ...customTranslations,
-    ...mobileTranslations,
 };

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -1,10 +1,11 @@
 import { customLanguageMap } from '../custom/translations';
+import { en as enCustom } from '../custom/translations/en';
 import { en } from './en';
 
 export type LangType = typeof en;
 
 export const languageMap = {
     default: en,
-    en,
+    en: { ...en, ...enCustom },
     ...customLanguageMap,
 };


### PR DESCRIPTION
`mobileTranslations` must be conditional. Before this patch basic translations were always overwritten.
`customTranslations` should be applied in language map, not in the file with translations