### PR TITLE
Fix: adjust modal spacing using padding, not absolute position

### DIFF
--- a/src/components/Beneficiaries/Beneficiaries.pcss
+++ b/src/components/Beneficiaries/Beneficiaries.pcss
@@ -38,16 +38,10 @@
   }
 
   .beneficiaries-add-address-modal--coin .cr-email-form {
-    min-height: calc(var(--big-gap) * 7.2);
-
     .pg-beneficiaries__error-text {
       color: var(--system-red);
       margin-left: 16px;
     }
-  }
-
-  .beneficiaries-add-address-modal--fiat .cr-email-form {
-    min-height: calc(var(--big-gap) * 12);
   }
 
   .beneficiaries-confirmation-modal .cr-email-form {
@@ -505,11 +499,12 @@
 
   .beneficiaries-fail-modal {
     .cr-email-form {
-      min-height: calc(var(--big-gap) * 4);
+      min-height: unset;
 
       &__form-content {
         align-items: center;
         display: flex;
+        flex-direction: column;
         justify-content: center;
 
         &__info {
@@ -517,8 +512,7 @@
           color: var(--primary-text-color);
           font-size: 14px;
           font-weight: normal;
-          position: absolute;
-          top: 12px;
+          padding: 12px 0;
         }
       }
 

--- a/src/components/EmailForm/EmailForm.pcss
+++ b/src/components/EmailForm/EmailForm.pcss
@@ -35,12 +35,8 @@
   }
 
   &__form-content {
-    bottom: var(--email-form-padding);
     box-sizing: border-box;
-    left: var(--email-form-padding);
-    position: absolute;
-    right: var(--email-form-padding);
-    top: 80px;
+    padding: var(--email-form-padding);
   }
 
   & > * {
@@ -113,15 +109,9 @@
   }
 
   &__button-wrapper {
-    background: transparent;
-    bottom: 0 !important;
     display: flex;
     flex-direction: column;
     justify-content: center;
-    left: 0;
-    min-height: calc(var(--gap) * 28);
-    position: absolute;
-    right: 0;
   }
 
   &__button-wrapper--empty {

--- a/src/mobile/styles/components/Modal.pcss
+++ b/src/mobile/styles/components/Modal.pcss
@@ -69,7 +69,7 @@
   }
 
   &__body {
-    height: 65vh;
+    height: 70vh;
     overflow-y: scroll;
   }
 }

--- a/src/mobile/styles/components/WalletWithdrawBody.pcss
+++ b/src/mobile/styles/components/WalletWithdrawBody.pcss
@@ -27,8 +27,8 @@
 
   &__confirmation {
     .cr-mobile-modal__block--open {
-      height: 50vh;
-      top: 47vh;
+      height: 55vh;
+      top: 42vh;
     }
   }
 
@@ -45,6 +45,12 @@
         color: var(--primary-text-color);
         text-align: left;
       }
+    }
+  }
+
+  .pg-beneficiaries {
+    .cr-mobile-modal__block--open {
+      top: 0;
     }
   }
 
@@ -133,6 +139,7 @@
         }
       }
     }
+
     .beneficiaries-add-address-modal {
       padding: 24px 14px;
       input {
@@ -148,6 +155,7 @@
         }
       }
     }
+
     &__header {
       &-back {
         display: none;
@@ -163,6 +171,10 @@
       &-close {
         flex: 0;
       }
+    }
+
+    &__body {
+      height: calc(100vh - 56px);
     }
   }
 }


### PR DESCRIPTION
https://jira.openware.work/browse/EMI-418

- For the modal spacing, use padding instead of absolute positioning.

- more bottom space
![Screen Shot 2564-01-29 at 18 08 16](https://user-images.githubusercontent.com/67998969/106271370-01b6b400-6262-11eb-93c8-7c242da6c373.png)

- fullscreen mobile modal for withdraw form
![Screen Shot 2564-01-29 at 18 13 06](https://user-images.githubusercontent.com/67998969/106271377-054a3b00-6262-11eb-8d64-021954d021c8.png)
