### PR TITLE
Fix: hide p2p wallet if exchange currency disabled

### DIFF
--- a/web/src/containers/Wallets/WalletsP2P/index.tsx
+++ b/web/src/containers/Wallets/WalletsP2P/index.tsx
@@ -54,7 +54,7 @@ const WalletsP2P: FC = (): ReactElement => {
     }, [history]);
 
     const retrieveData = React.useCallback(() => {
-        const list = nonZeroSelected ? filteredWallets.filter(i => i.balance && Number(i.balance) > 0) : filteredWallets;
+        const list = nonZeroSelected ? filteredWallets.filter(i => i.currency && i.balance && Number(i.balance) > 0) : filteredWallets.filter(i => i.currency);
 
         return !list.length ? [[]] : list.map((item, index) => {
             const {

--- a/web/src/containers/Wallets/WalletsTransfer/index.tsx
+++ b/web/src/containers/Wallets/WalletsTransfer/index.tsx
@@ -83,7 +83,7 @@ const WalletsTransfer: FC<Props> = (props: Props): ReactElement => {
 
 
     const formattedWallets = useCallback(() => {
-        const list = nonZeroSelected ? filteredWallets.filter(i => i.balance && Number(i.balance) > 0) : filteredWallets;
+        const list = nonZeroSelected ? filteredWallets.filter(i => i.currency && i.balance && Number(i.balance) > 0) : filteredWallets.filter(i => i.currency);
 
         return list.map((wallet: Wallet) => ({
             ...wallet,


### PR DESCRIPTION
Fix hide p2p wallet from list if exchange currency is disabled from Tower and fix swap transfer error.