### PR TITLE
Fix: disable click for cancelled p2p order in history list

### DIFF
--- a/web/src/containers/P2P/TradesHistory/index.tsx
+++ b/web/src/containers/P2P/TradesHistory/index.tsx
@@ -85,8 +85,9 @@ const TradesHistory: FC = (): ReactElement => {
 
     const onRowClick = useCallback((index: string) => {
         const orderId = list[index]?.id;
-        orderId && history.push(`/p2p/order/${orderId}`);
-    }, [list]);
+        const orderState = list[index]?.state;
+        orderId && orderState !== 'cancelled' && history.push(`/p2p/order/${orderId}`);
+    }, [history, list]);
 
     const renderContent = useMemo(() => {
         return (


### PR DESCRIPTION
[Jira Ticket](https://openware-inc.atlassian.net/browse/NAIR-207)

Remove ability to click on Cancelled item in P2P trade history list.