### PR TITLE
Fix: add asset/fiat column to p2p history

### DIFF
--- a/web/src/containers/P2P/TradesHistory/index.tsx
+++ b/web/src/containers/P2P/TradesHistory/index.tsx
@@ -54,6 +54,7 @@ const TradesHistory: FC = (): ReactElement => {
         return [
             translate('page.body.p2p.order_history.date'),
             translate('page.body.p2p.order_history.side'),
+            translate('page.body.p2p.order_history.asset'),
             translate('page.body.p2p.order_history.price'),
             translate('page.body.p2p.order_history.quantity'),
             translate('page.body.p2p.order_history.counterparty'),
@@ -72,7 +73,8 @@ const TradesHistory: FC = (): ReactElement => {
         return [
             localeDate(created_at, 'fullDate'),
             <span style={{ color: sideColored.color }}>{sideColored.text}</span>,
-            `${Decimal.format(price, pricePrecision || DEFAULT_FIAT_PRECISION, ',')} ${base.toUpperCase()}/${quote.toUpperCase()}`,
+            `${base.toUpperCase()}/${quote.toUpperCase()}`,
+            `${Decimal.format(price, pricePrecision || DEFAULT_FIAT_PRECISION, ',')} ${quote.toUpperCase()}`,
             `${Decimal.format(amount, amountPrecision || DEFAULT_CCY_PRECISION, ',')} ${base.toUpperCase()}`,
             <span>{user?.user_nickname || uid}</span>,
             <span style={{ color: stateColored.color }}>{stateColored.text}</span>,

--- a/web/src/custom/translations/ru.ts
+++ b/web/src/custom/translations/ru.ts
@@ -1189,6 +1189,7 @@ export const ru: LangType = {
     'page.body.p2p.order_history.back': 'Back to P2P',
     'page.body.p2p.order_history.date': 'Date',
     'page.body.p2p.order_history.side': 'Side',
+    'page.body.p2p.order_history.asset': 'Asset/Fiat',
     'page.body.p2p.order_history.price': 'Price',
     'page.body.p2p.order_history.quantity': 'Quantity',
     'page.body.p2p.order_history.counterparty': 'Counterparty',

--- a/web/src/translations/en.ts
+++ b/web/src/translations/en.ts
@@ -1186,6 +1186,7 @@ export const en = {
     'page.body.p2p.order_history.back': 'Back to P2P',
     'page.body.p2p.order_history.date': 'Date',
     'page.body.p2p.order_history.side': 'Side',
+    'page.body.p2p.order_history.asset': 'Asset/Fiat',
     'page.body.p2p.order_history.price': 'Price',
     'page.body.p2p.order_history.quantity': 'Quantity',
     'page.body.p2p.order_history.counterparty': 'Counterparty',


### PR DESCRIPTION
[Jira Ticket](https://openware-inc.atlassian.net/browse/NAIR-227)

Add Asset/Fiat column to P2P trade history table.