### PR TITLE
Fix: login without refreshing should also start check login status

### DIFF
--- a/web/src/modules/user/auth/sagas/logoutSaga.ts
+++ b/web/src/modules/user/auth/sagas/logoutSaga.ts
@@ -27,5 +27,9 @@ export function* logoutSaga(action: LogoutFetch) {
                 actionError: logoutError,
             },
         }));
+
+        if (error.messages.indexOf('identity.session.not_found') > -1) {
+            yield put(userReset());
+        }
     }
 }

--- a/web/src/modules/user/auth/sagas/logoutSaga.ts
+++ b/web/src/modules/user/auth/sagas/logoutSaga.ts
@@ -28,7 +28,7 @@ export function* logoutSaga(action: LogoutFetch) {
             },
         }));
 
-        if (error.messages.indexOf('identity.session.not_found') > -1) {
+        if (error.message.indexOf('identity.session.not_found') > -1) {
             yield put(userReset());
         }
     }

--- a/web/src/routes/Layout/index.tsx
+++ b/web/src/routes/Layout/index.tsx
@@ -409,7 +409,9 @@ class LayoutComponent extends React.Component<LayoutProps, LayoutState> {
         const timeleft = this.getLastAction() + parseFloat(minutesUntilAutoLogout()) * 60 * 1000;
         const diff = timeleft - now;
         const isTimeout = diff < 0;
-        if (isTimeout && user.email) {
+        const token = localStorage.getItem('csrfToken');
+
+        if (isTimeout && user.email || this.props.isLoggedIn && !token) {
             if (user.state === 'active') {
                 this.handleChangeExpSessionModalState();
             }

--- a/web/src/routes/Layout/index.tsx
+++ b/web/src/routes/Layout/index.tsx
@@ -237,6 +237,11 @@ class LayoutComponent extends React.Component<LayoutProps, LayoutState> {
         if (!this.props.user.email && nextProps.user.email && !this.props.location.pathname.includes('/setup')) {
             this.props.userFetch();
         }
+
+        if (!this.props.isLoggedIn && nextProps.isLoggedIn && !this.props.user.email) {
+            this.initInterval();
+            this.check();
+        }
     }
 
     public componentDidUpdate(prevProps: LayoutProps) {
@@ -410,6 +415,7 @@ class LayoutComponent extends React.Component<LayoutProps, LayoutState> {
             }
 
             this.props.logout();
+            clearInterval(this.timer);
         }
     };
 

--- a/web/src/routes/Layout/index.tsx
+++ b/web/src/routes/Layout/index.tsx
@@ -409,9 +409,8 @@ class LayoutComponent extends React.Component<LayoutProps, LayoutState> {
         const timeleft = this.getLastAction() + parseFloat(minutesUntilAutoLogout()) * 60 * 1000;
         const diff = timeleft - now;
         const isTimeout = diff < 0;
-        const token = localStorage.getItem('csrfToken');
 
-        if (isTimeout && user.email || this.props.isLoggedIn && !token) {
+        if (isTimeout && user.email) {
             if (user.state === 'active') {
                 this.handleChangeExpSessionModalState();
             }


### PR DESCRIPTION
https://openware-inc.atlassian.net/browse/OPSM-2279

- When a user login without refreshing browser, it was not initiating interval check(long enough time since getLastAction)
- When the system auto logout users without activity, it was not clearing interval timer
- If multiple logged in tabs open and one of them timeout the session, the rest of tabs should detect it and redirect to trading page