### PR TITLE
Fix: beneficiaries add permission error alert

### DIFF
--- a/web/mocks/api/v2/peatio/account/beneficiaries/POST--currency=btc&name=test&data.address=1KFHE7w8BhaENAswwryaoccDb6qcT6DbYY.mock
+++ b/web/mocks/api/v2/peatio/account/beneficiaries/POST--currency=btc&name=test&data.address=1KFHE7w8BhaENAswwryaoccDb6qcT6DbYY.mock
@@ -1,0 +1,9 @@
+HTTP/2 403
+Content-Type: application/json; charset=utf-8
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: GET, POST, DELETE, PUT, PATCH, OPTIONS, HEAD
+Access-Control-Max-Age: 3600
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Headers: content-type, x-csrf-token
+
+{"errors":["account.withdraw.not_permitted"]}

--- a/web/src/containers/Wallets/WalletsSpot/index.tsx
+++ b/web/src/containers/Wallets/WalletsSpot/index.tsx
@@ -42,6 +42,7 @@ import {
     selectWallets,
     selectWalletsLoading,
     selectWithdrawSuccess,
+    selectBeneficiariesCreateError,
     setMobileWalletUi,
     Ticker,
     User,
@@ -68,6 +69,7 @@ interface ReduxProps {
     tickers: {
         [key: string]: Ticker,
     };
+    beneficiariesAddError: any,
 }
 
 interface DispatchProps {
@@ -245,6 +247,12 @@ class WalletsSpotComponent extends React.Component<Props, WalletsState> {
             const selectedCurrency = (next.wallets[selectedWalletIndex] || { currency: '' }).currency;
 
             this.props.fetchBeneficiaries({ currency_id: selectedCurrency.toLowerCase() });
+        }
+
+        if (!this.props.beneficiariesAddError && next.beneficiariesAddError && next.beneficiariesAddError.message) {
+            if (next.beneficiariesAddError.message.indexOf('account.withdraw.not_permitted') > -1) {
+                this.props.fetchSuccess({ message: next.beneficiariesAddError.message, type: 'error'});
+            }
         }
     }
 
@@ -640,6 +648,7 @@ const mapStateToProps = (state: RootState): ReduxProps => ({
     beneficiariesDeleteSuccess: selectBeneficiariesDeleteSuccess(state),
     currencies: selectCurrencies(state),
     beneficiariesAddSuccess: selectBeneficiariesCreateSuccess(state),
+    beneficiariesAddError: selectBeneficiariesCreateError(state),
 });
 
 const mapDispatchToProps: MapDispatchToProps<DispatchProps, {}> = dispatch => ({

--- a/web/src/modules/public/alert/sagas/handleAlertSaga.ts
+++ b/web/src/modules/public/alert/sagas/handleAlertSaga.ts
@@ -54,9 +54,6 @@ export function* handleAlertSaga(action: AlertPush) {
                 if (action.payload.message.indexOf('jwt.decode_and_verify') > -1) {
                     yield call(callAlertData, action);
                 }
-                if (action.payload.message.indexOf('account.withdraw.not_permitted') > -1) {
-                    yield call(callAlertData, action);
-                }
 
                 return;
             case 422:


### PR DESCRIPTION
https://openware-inc.atlassian.net/browse/OPSM-2333?focusedCommentId=14186

When user account level is less than 3, attempt to add beneficiary will fail with `account.withdraw.not_permitted`.
In this case we should SHOW alert message while navigating different currencies in wallet page should NOT show the same alert.