### PR TITLE
Fix: beneficiaries add permission error alert (3-0-stable)

### DIFF
--- a/web/mocks/api/v2/peatio/account/beneficiaries/POST--currency_id=btc&name=test&data.address=1KFHE7w8BhaENAswwryaoccDb6qcT6DbYY.mock
+++ b/web/mocks/api/v2/peatio/account/beneficiaries/POST--currency_id=btc&name=test&data.address=1KFHE7w8BhaENAswwryaoccDb6qcT6DbYY.mock
@@ -1,0 +1,9 @@
+HTTP/2 403
+Content-Type: application/json; charset=utf-8
+Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods: GET, POST, DELETE, PUT, PATCH, OPTIONS, HEAD
+Access-Control-Max-Age: 3600
+Access-Control-Allow-Credentials: true
+Access-Control-Allow-Headers: content-type, x-csrf-token
+
+{"errors":["account.withdraw.not_permitted"]}

--- a/web/src/components/Beneficiaries/BeneficiariesAddModal.tsx
+++ b/web/src/components/Beneficiaries/BeneficiariesAddModal.tsx
@@ -6,8 +6,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import { validateBeneficiaryAddress } from '../../helpers/validateBeneficiaryAddress';
 import { Modal } from '../../mobile/components/Modal';
 import {
+    alertPush,
     beneficiariesCreate,
     BeneficiaryBank,
+    selectBeneficiariesCreateError,
     selectMobileDeviceState,
 } from '../../modules';
 import { CustomInput } from '../CustomInput';
@@ -48,6 +50,7 @@ const BeneficiariesAddModalComponent: React.FC<Props> = (props: Props) => {
     const { formatMessage } = useIntl();
     const dispatch = useDispatch();
 
+    const beneficiariesAddError = useSelector(selectBeneficiariesCreateError);
     const isMobileDevice = useSelector(selectMobileDeviceState);
     const isRipple = React.useMemo(() => currency === 'xrp', [currency]);
 
@@ -87,6 +90,14 @@ const BeneficiariesAddModalComponent: React.FC<Props> = (props: Props) => {
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [handleToggleAddAddressModal]);
+
+    React.useEffect(() => {
+        if (beneficiariesAddError && beneficiariesAddError.message) {
+            if (beneficiariesAddError.message.indexOf('account.withdraw.not_permitted') > -1) {
+                dispatch(alertPush({ message: beneficiariesAddError.message, type: 'error'}));
+            }
+        }
+    }, [beneficiariesAddError, dispatch]);
 
     const renderAddAddressModalHeader = React.useMemo(() => {
         return (

--- a/web/src/modules/public/alert/sagas/handleAlertSaga.ts
+++ b/web/src/modules/public/alert/sagas/handleAlertSaga.ts
@@ -54,9 +54,6 @@ export function* handleAlertSaga(action: AlertPush) {
                 if (action.payload.message.indexOf('jwt.decode_and_verify') > -1) {
                     yield call(callAlertData, action);
                 }
-                if (action.payload.message.indexOf('account.withdraw.not_permitted') > -1) {
-                    yield call(callAlertData, action);
-                }
 
                 return;
             case 422:


### PR DESCRIPTION
https://openware-inc.atlassian.net/browse/OPSM-2333?focusedCommentId=14186

When user account level is less than 3, attempt to add beneficiary will fail with account.withdraw.not_permitted.
In this case we should SHOW alert message while navigating different currencies in wallet page should NOT show the same alert.