### PR TITLE
Fix: make bech32 btc address valid in cryptoRegExp

### DIFF
--- a/web/src/components/Beneficiaries/Beneficiaries.pcss
+++ b/web/src/components/Beneficiaries/Beneficiaries.pcss
@@ -38,9 +38,16 @@
   }
 
   .beneficiaries-add-address-modal--coin .cr-email-form {
-    .pg-beneficiaries__error-text {
-      color: var(--system-red);
-      margin-left: 16px;
+    .pg-beneficiaries {
+      &__error-text {
+        color: var(--system-red);
+        margin-left: 16px;
+      }
+
+      &__warning-text {
+        color: var(--system-yellow);
+        margin-left: 16px;
+      }
     }
   }
 

--- a/web/src/components/Beneficiaries/BeneficiariesAddModal.tsx
+++ b/web/src/components/Beneficiaries/BeneficiariesAddModal.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Button } from 'react-bootstrap';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
-import { validateBeneficiaryAddress } from '../../helpers/validateBeneficiaryAddress';
+import { validateBeneficiaryAddress, validateBeneficiaryTestnetAddress } from '../../helpers';
 import { Modal } from '../../mobile/components/Modal';
 import {
     beneficiariesCreate,
@@ -21,6 +21,7 @@ interface Props {
 const BeneficiariesAddModalComponent: React.FC<Props> = (props: Props) => {
     const [coinAddress, setCoinAddress] = React.useState('');
     const [coinAddressValid, setCoinAddressValid] = React.useState(false);
+    const [coinTestnetAddressValid, setCoinTestnetAddressValid] = React.useState(false);
     const [coinBeneficiaryName, setCoinBeneficiaryName] = React.useState('');
     const [coinDescription, setCoinDescription] = React.useState('');
     const [coinDestinationTag, setCoinDestinationTag] = React.useState('');
@@ -61,6 +62,7 @@ const BeneficiariesAddModalComponent: React.FC<Props> = (props: Props) => {
         setCoinDescriptionFocused(false);
         setCoinDestinationTagFocused(false);
         setCoinAddressValid(false);
+        setCoinTestnetAddressValid(false);
 
         setFiatAccountNumber('');
         setFiatName('');
@@ -196,8 +198,10 @@ const BeneficiariesAddModalComponent: React.FC<Props> = (props: Props) => {
 
     const validateCoinAddressFormat = React.useCallback((value: string) => {
         const coinAddressValidator = validateBeneficiaryAddress.cryptocurrency(currency, true);
+        const coinAddressTestnetValidator = validateBeneficiaryTestnetAddress.cryptocurrency(currency, true);
 
         setCoinAddressValid(coinAddressValidator.test(value.trim()));
+        setCoinTestnetAddressValid(coinAddressTestnetValidator.test(value.trim()));
     }, [currency]);
 
     const handleChangeFieldValue = React.useCallback((key: string, value: string) => {
@@ -317,13 +321,23 @@ const BeneficiariesAddModalComponent: React.FC<Props> = (props: Props) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [coinAddress]);
 
+    const renderTestnetAddressMessage = React.useMemo(() => {
+        return (
+          <div className="cr-email-form__group">
+              <span className="pg-beneficiaries__warning-text">{formatMessage({ id: 'page.body.wallets.beneficiaries.addAddressModal.body.testnetAddress' })}</span>
+          </div>
+        );
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [coinAddress]);
+
     const renderAddAddressModalCryptoBody = React.useMemo(() => {
-        const isDisabled = !coinAddress || !coinBeneficiaryName || !coinAddressValid;
+        const isDisabled = !coinAddress || !coinBeneficiaryName || (!coinAddressValid && !coinTestnetAddressValid);
 
         return (
             <div className="cr-email-form__form-content">
                 {renderAddAddressModalBodyItem('coinAddress')}
-                {!coinAddressValid && coinAddress && renderInvalidAddressMessage}
+                {!coinAddressValid && !coinTestnetAddressValid && coinAddress && renderInvalidAddressMessage}
+                {!coinAddressValid && coinTestnetAddressValid && coinAddress && renderTestnetAddressMessage}
                 {renderAddAddressModalBodyItem('coinBeneficiaryName')}
                 {renderAddAddressModalBodyItem('coinDescription', true)}
                 {isRipple && renderAddAddressModalBodyItem('coinDestinationTag', true)}

--- a/web/src/custom/translations/ru.ts
+++ b/web/src/custom/translations/ru.ts
@@ -234,6 +234,7 @@ export const ru: LangType = {
 
     'page.body.wallets.beneficiaries.addAddressModal.body.coinAddress': 'Blockchain Address',
     'page.body.wallets.beneficiaries.addAddressModal.body.invalidAddress': 'Invalid Address',
+    'page.body.wallets.beneficiaries.addAddressModal.body.testnetAddress': 'WARNING! This is testnet address',
     'page.body.wallets.beneficiaries.addAddressModal.body.coinBeneficiaryName': 'Beneficiary Name',
     'page.body.wallets.beneficiaries.addAddressModal.body.coinDescription': 'Description (optional)',
     'page.body.wallets.beneficiaries.addAddressModal.body.coinDestinationTag': 'Destination Tag (optional)',

--- a/web/src/helpers/index.ts
+++ b/web/src/helpers/index.ts
@@ -49,3 +49,5 @@ export * from './mergeObjects';
 export * from './titleCase';
 export * from './convertSecondToMinute';
 export * from './getCountDownDate';
+export * from './validateBeneficiaryTestnetAddress';
+export * from './validateBeneficiaryAddress';

--- a/web/src/helpers/validateBeneficiaryAddress.test.ts
+++ b/web/src/helpers/validateBeneficiaryAddress.test.ts
@@ -7,11 +7,6 @@ describe('Beneficiary Address Validaity Test', () => {
         expect(coinAddressValidator.test('38T68JavN2m1VHodiNsBq9vj8v5zA6QEsa')).toBeTruthy();
     });
 
-    it('should pass BTC TestNet address', () => {
-        const coinAddressValidator = validateBeneficiaryAddress.cryptocurrency('btc', true);
-        expect(coinAddressValidator.test('2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc')).toBeTruthy();
-    });
-
     it('should pass BCH address', () => {
         const coinAddressValidator = validateBeneficiaryAddress.cryptocurrency('bch', true);
         expect(coinAddressValidator.test('bitcoincash:qqrxa0h9jqnc7v4wmj9ysetsp3y7w9l36u8gnnjulq')).toBeTruthy();
@@ -81,6 +76,7 @@ describe('Wrong Address Format Test', () => {
         expect(coinAddressValidator.test('18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX/')).toBeFalsy();
         expect(coinAddressValidator.test('18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX,')).toBeFalsy();
         expect(coinAddressValidator.test('+18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX')).toBeFalsy();
+        expect(coinAddressValidator.test('2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc')).toBeFalsy();
     });
 
     it('should not pass wrong BCH address', () => {

--- a/web/src/helpers/validateBeneficiaryAddress.ts
+++ b/web/src/helpers/validateBeneficiaryAddress.ts
@@ -1,5 +1,5 @@
 const cryptoRegExps = {
-    btc: '[123][a-km-zA-HJ-NP-Z1-9]{26,35}',
+    btc: '([13][a-km-zA-HJ-NP-Z1-9]{25,34})|((?=bc1[a-km-zA-HJ-NP-Z1-9]*)(?:.{42}|.{62}))',
     bch: '((bitcoincash|bchreg|bchtest):)?(q|p)[a-z0-9]{41}',
     eth: '0x[a-fA-F0-9]{40}',
     ltc: '[LM3][a-km-zA-HJ-NP-Z1-9]{26,33}',

--- a/web/src/helpers/validateBeneficiaryTestnetAddress.test.ts
+++ b/web/src/helpers/validateBeneficiaryTestnetAddress.test.ts
@@ -1,0 +1,54 @@
+import { validateBeneficiaryTestnetAddress } from './validateBeneficiaryTestnetAddress';
+
+describe('Testnet Beneficiary Address Validaity Test', () => {
+    it('should pass TestNet BTC address', () => {
+        const coinAddressValidator = validateBeneficiaryTestnetAddress.cryptocurrency('btc', true);
+        expect(coinAddressValidator.test('tb1qnjf0v63jyryrkqdml29f2hdz9m0n6l5ypkq7x5m')).toBeTruthy();
+        expect(coinAddressValidator.test('2MyhTqkLXs4K9PhRN4HeRuZJNZTYYCvJpNw')).toBeTruthy();
+        expect(coinAddressValidator.test('mkkJGguo6Yu3oh1RMGxJF5JDmU58Tew5jy')).toBeTruthy();
+        expect(coinAddressValidator.test('2N4Sworbnqv1Ug4fnmukBeAqWPMx8nNNwHH')).toBeTruthy();
+        expect(coinAddressValidator.test('mfWxJ45yp2SFn7UciZyNpvDKrzbhyfKrY8')).toBeTruthy();
+    });
+});
+
+describe('Address with Wrong Format Test', () => {
+    it('should not pass wrong BTC address', () => {
+        const coinAddressValidator = validateBeneficiaryTestnetAddress.cryptocurrency('btc', true);
+        expect(coinAddressValidator.test('18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX ')).toBeFalsy();
+        expect(coinAddressValidator.test(' 18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX ')).toBeFalsy();
+        expect(coinAddressValidator.test(' 18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX .')).toBeFalsy();
+        expect(coinAddressValidator.test('18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX.')).toBeFalsy();
+        expect(coinAddressValidator.test('18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX+')).toBeFalsy();
+        expect(coinAddressValidator.test('18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX-')).toBeFalsy();
+        expect(coinAddressValidator.test('18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX/')).toBeFalsy();
+        expect(coinAddressValidator.test('18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX,')).toBeFalsy();
+        expect(coinAddressValidator.test('+18cBEMRxXHqzWWCxZNtU91F5sbUNKhL5PX')).toBeFalsy();
+    });
+
+    it('should not pass MainNet BTC address', () => {
+        const coinAddressValidator = validateBeneficiaryTestnetAddress.cryptocurrency('btc', true);
+        expect(coinAddressValidator.test('17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem')).toBeFalsy();
+        expect(coinAddressValidator.test('38T68JavN2m1VHodiNsBq9vj8v5zA6QEsa')).toBeFalsy();
+        expect(coinAddressValidator.test('bc1qtql9qte2350ftjl5gfalplqg69e5efr9cd0v8nh06a7hvs7s5u9snsd38g')).toBeFalsy();
+        expect(coinAddressValidator.test('3Eb56XPpL3nh8Jjx2KGrYm1qob2Rz14p13')).toBeFalsy();
+        expect(coinAddressValidator.test('1qKBM6soCLKDe7mC6Vee6hJcBM45jB6kS')).toBeFalsy();
+    });
+});
+
+describe('Unsported Coin', () => {
+    it('should detect unsupported coin XXX', () => {
+        const coinAddressValidator = validateBeneficiaryTestnetAddress.cryptocurrency('xxx', true);
+        expect(coinAddressValidator.test('XyzXXyyzZ')).toBeTruthy();
+    });
+});
+
+describe('Not Exact Match Test', () => {
+    it('validate not exact match address', () => {
+        const coinAddressValidator = validateBeneficiaryTestnetAddress.cryptocurrency('btc', false);
+        expect(coinAddressValidator.test('tb1qnjf0v63jyryrkqdml29f2hdz9m0n6l5ypkq7x5m 2MyhTqkLXs4K9PhRN4HeRuZJNZTYYCvJpNw')).toBeTruthy();
+        expect(coinAddressValidator.test(`
+            mfWxJ45yp2SFn7UciZyNpvDKrzbhyfKrY8
+            mkkJGguo6Yu3oh1RMGxJF5JDmU58Tew5jy
+        `)).toBeTruthy();
+    });
+});

--- a/web/src/helpers/validateBeneficiaryTestnetAddress.ts
+++ b/web/src/helpers/validateBeneficiaryTestnetAddress.ts
@@ -1,0 +1,25 @@
+const cryptoRegExps = {
+    btc: '((tb1|[2nm]|bcrt)[a-zA-HJ-NP-Z0-9]{25,40})',
+};
+
+const buildRegExp = (bodyExp: string, exact?: boolean) =>
+    exact ? new RegExp(`^(${bodyExp})$`) : new RegExp(`\\b(?:${bodyExp})\\b`, 'g');
+
+const cryptoAddress = (cryptoCurrency, exact?: boolean) => {
+    return buildRegExp(cryptoRegExps[cryptoCurrency], exact);
+};
+
+cryptoAddress.cryptocurrency = (cryptoCurrency, exact) => {
+    if (cryptoRegExps.hasOwnProperty(cryptoCurrency)) {
+        const bodyExp = cryptoRegExps[cryptoCurrency];
+
+        return buildRegExp(bodyExp, exact);
+    } else {
+        // throw new Error('Unsupported cryptocurrency');
+
+        //TODO: will need to add more supported testnet addresses later
+        return buildRegExp('', false);
+    }
+};
+
+export const validateBeneficiaryTestnetAddress = cryptoAddress;

--- a/web/src/translations/en.ts
+++ b/web/src/translations/en.ts
@@ -227,6 +227,7 @@ export const en = {
 
     'page.body.wallets.beneficiaries.addAddressModal.body.coinAddress': 'Blockchain Address',
     'page.body.wallets.beneficiaries.addAddressModal.body.invalidAddress': 'Invalid Address',
+    'page.body.wallets.beneficiaries.addAddressModal.body.testnetAddress': 'WARNING! This is testnet address',
     'page.body.wallets.beneficiaries.addAddressModal.body.coinBeneficiaryName': 'Beneficiary Name',
     'page.body.wallets.beneficiaries.addAddressModal.body.coinDescription': 'Description (optional)',
     'page.body.wallets.beneficiaries.addAddressModal.body.coinDestinationTag': 'Destination Tag (optional)',


### PR DESCRIPTION
Valid BTC mainnet address starts with 1 or 3, so 2 deleted from the set of expected characters. 

Added validation for bech32-format addresses, which starts from `bc1` and can contain either 42 or 62 characters.

Added separated validation for testnet addresses (for now only for btc), and inform warning (which still let user to create beneficiary).