### PR TITLE
fix: golang:alpine build fail in Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine AS go-builder
+FROM golang:1.15.12-alpine AS go-builder
 
 WORKDIR /build
 ENV CGO_ENABLED=1 \


### PR DESCRIPTION
Docker build failed in Drone with `golang:1.15.13-alpine` (it is `golang:1.15-alpine` at this moment)
if downgrade to `1.15.12`. the build will succeed.
however, we will lose the opportunity to use the latest patch in the future if we hard set the version like this.

**Error**
```sh
Step 8/26 : RUN make all
--
158 | ---> Running in 24eebcbe65f1
159 | go build --ldflags "-X main.Version=$(cat VERSION)" -o bin/sonic app.go
160 | make: /bin/sh: Operation not permitted
161 | make: *** [Makefile:6: sonic] Error 127
162 | The command '/bin/sh -c make all' returned a non-zero code: 2
163 | time="2021-07-01T12:02:37Z" level=fatal msg="exit status 2"
```