### PR TITLE
Fix: markup for locked screen

### DIFF
--- a/web/src/components/LockedComponent/LockedComponent.pcss
+++ b/web/src/components/LockedComponent/LockedComponent.pcss
@@ -6,6 +6,7 @@
   height: 100%;
   justify-content: center;
   width: 100%;
+  padding: 36px;
 
   &__content {
     font-size: 14px;

--- a/web/src/components/LockedComponent/LockedComponent.pcss
+++ b/web/src/components/LockedComponent/LockedComponent.pcss
@@ -1,17 +1,16 @@
 .cr-locked {
-  height: 100%;
-  width: 100%;
+  align-items: center;
   background: var(--body-background-color);
   display: flex;
   flex-direction: column;
-  align-items: center;
+  height: 100%;
   justify-content: center;
-  padding: 36px;
+  width: 100%;
 
   &__content {
     font-size: 14px;
-    line-height: 22px;
     letter-spacing: 0.1px;
+    line-height: 22px;
     max-width: 184px;
     text-align: center;
   }
@@ -24,5 +23,10 @@
     path {
       fill: var(--button-secondary-cta-text-color);
     }
+  }
+
+  &__btn-content {
+    padding: 10px;
+    font-size: 14px;
   }
 }

--- a/web/src/components/LockedComponent/index.tsx
+++ b/web/src/components/LockedComponent/index.tsx
@@ -24,6 +24,7 @@ export const LockedComponent: FC<Props> = (props: Props): ReactElement => {
                 onClick={handleClick}
                 size="lg"
                 variant="secondary"
+                className="cr-locked__btn-content"
             >
                 {buttonText} <ArrowRight className="cr-locked__btn-icon" />
             </Button>

--- a/web/src/mobile/styles/components/CreateOrder.pcss
+++ b/web/src/mobile/styles/components/CreateOrder.pcss
@@ -7,6 +7,10 @@
   margin-bottom: 4px;
   width: 100%;
 
+  .cr-locked {
+    padding: 0;
+  }
+
   &__row-double {
     align-items: flex-start;
     background: var(--body-background-color);


### PR DESCRIPTION
https://openware-inc.atlassian.net/browse/OPD-570

Fix: markup for locked screen
<img width="468" alt="image" src="https://user-images.githubusercontent.com/38152090/124509537-97df9f00-ddeb-11eb-8894-0cd8091d99f2.png">
