### PR TITLE
Fix: translations and thousands seperator of open orders  (#732)

### DIFF
--- a/web/src/constants/index.ts
+++ b/web/src/constants/index.ts
@@ -124,3 +124,4 @@ export const colors = {
 };
 
 export const FIXED_VOL_PRECISION = 2;
+export const DEFAULT_PERCENTAGE_PRECISION = 2;

--- a/web/src/containers/HeaderToolbar/index.tsx
+++ b/web/src/containers/HeaderToolbar/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+import { DEFAULT_PERCENTAGE_PRECISION } from 'src/constants';
 import { IntlProps } from '../../';
 import { Decimal } from '../../components/Decimal';
 import {
@@ -70,7 +71,7 @@ class HeaderToolbarContainer extends React.Component<Props> {
                 </div>
                 <div className="pg-header__toolbar-item">
                     <p className={`pg-header__toolbar-item-value pg-header__toolbar-item-value-${cls}`}>
-                        {currentMarket && (marketTickers[currentMarket.id] || defaultTicker).price_change_percent}
+                        {currentMarket && this.formatPercentageValue((marketTickers[currentMarket.id] || defaultTicker).price_change_percent)}
                     </p>
                     <p className="pg-header__toolbar-item-text">
                         {this.translate('page.body.trade.toolBar.change')}
@@ -79,6 +80,14 @@ class HeaderToolbarContainer extends React.Component<Props> {
             </div>
         );
     }
+
+    private formatPercentageValue = (value: string) => (
+        <React.Fragment>
+            {value?.charAt(0)}
+            {Decimal.format(value?.slice(1, -1), DEFAULT_PERCENTAGE_PRECISION, ',')}
+            %
+        </React.Fragment>
+    );
 
     private getTickerValue = (value: string) => {
         const { marketTickers, currentMarket } = this.props;

--- a/web/src/containers/Markets/index.tsx
+++ b/web/src/containers/Markets/index.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { Spinner } from 'react-bootstrap';
 import { useIntl } from 'react-intl';
 import { useDispatch, useSelector } from 'react-redux';
+import { DEFAULT_PERCENTAGE_PRECISION } from 'src/constants';
 import { incrementalOrderBook } from '../../api';
 import { Decimal } from '../../components/Decimal';
 import { Markets } from '../../components/Markets';
@@ -34,6 +35,13 @@ export const MarketsComponent = () => {
         formatMessage({ id: 'page.body.trade.header.markets.content.change' }),
     ]), [formatMessage]);
 
+    const formatPercentageValue = React.useCallback((value: string) => (
+        <React.Fragment>
+            {value?.charAt(0)}
+            {Decimal.format(value?.slice(1, -1), DEFAULT_PERCENTAGE_PRECISION, ',')}
+            %
+        </React.Fragment>
+    ), []);
 
     const mapMarkets = React.useCallback(() => {
         const defaultTicker = {
@@ -49,7 +57,7 @@ export const MarketsComponent = () => {
             return ([
                 market.name,
                 Decimal.format(Number((marketTickers[market.id] || defaultTicker).last), market.amount_precision, ','),
-                (marketTickers[market.id] || defaultTicker).price_change_percent,
+                formatPercentageValue((marketTickers[market.id] || defaultTicker).price_change_percent),
             ])
         });
     }, [marketTickers, marketsData]);

--- a/web/src/containers/MarketsTable/index.tsx
+++ b/web/src/containers/MarketsTable/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import { DEFAULT_PERCENTAGE_PRECISION } from 'src/constants';
 import { Decimal, TickerTable } from '../../components';
 import {
     useMarketsFetch,
@@ -70,12 +71,22 @@ const MarketsTableComponent = props => {
         currentBidUnitMarkets = currentBidUnitMarkets.length ? currentBidUnitMarkets.filter(market => market.quote_unit === currentBidUnit) : [];
     }
 
+    const formatPercentageValue = React.useCallback((value: string) => (
+        <React.Fragment>
+            {value?.charAt(0)}
+            <Decimal fixed={DEFAULT_PERCENTAGE_PRECISION} thousSep=",">
+                {value?.slice(1, -1)}
+            </Decimal>
+            %
+        </React.Fragment>
+    ), []);
+
     const formattedMarkets = currentBidUnitMarkets.length ? currentBidUnitMarkets.map(market =>
         ({
             ...market,
             last: Decimal.format(Number((marketTickers[market.id] || defaultTicker).last), market.amount_precision),
             open: Decimal.format(Number((marketTickers[market.id] || defaultTicker).open), market.price_precision),
-            price_change_percent: String((marketTickers[market.id] || defaultTicker).price_change_percent),
+            price_change_percent: formatPercentageValue((marketTickers[market.id] || defaultTicker).price_change_percent),
             high: Decimal.format(Number((marketTickers[market.id] || defaultTicker).high), market.amount_precision),
             low: Decimal.format(Number((marketTickers[market.id] || defaultTicker).low), market.amount_precision),
             volume: Decimal.format(Number((marketTickers[market.id] || defaultTicker).volume), market.amount_precision),

--- a/web/src/containers/OrderBook/index.tsx
+++ b/web/src/containers/OrderBook/index.tsx
@@ -250,7 +250,7 @@ class OrderBookContainer extends React.Component<Props, State> {
         const amountFixed = currentMarket ? currentMarket.amount_precision : 0;
 
         if (isMobileDevice) {
-            return this.getOrderBookData(isMobileDevice, isLarge, side, array, priceFixed, amountFixed, total, message);
+            return this.getOrderBookData(isLarge, side, array, priceFixed, amountFixed, total, message);
         }
 
         return array.length ? array.map((item, i) => {
@@ -283,12 +283,14 @@ class OrderBookContainer extends React.Component<Props, State> {
         }) : [[[''], message]];
     };
 
-    private getOrderBookData = (isMobileDevice, isLarge, side, array, priceFixed, amountFixed, total, message) => {
+    private getOrderBookData = (isLarge, side, array, priceFixed, amountFixed, total, message) => {
         return array.length ? array.map((item, i) => {
             const [price] = item;
 
             switch (side) {
                 case 'asks':
+                    total = isLarge ? accumulateVolume(array) : accumulateVolume(array.slice(0).reverse()).slice(0).reverse();
+
                     return [
                         <Decimal key={i} fixed={priceFixed} thousSep="," prevValue={array[i + 1] ? array[i + 1][0] : 0}>{price}</Decimal>,
                         <Decimal key={i} fixed={amountFixed} thousSep=",">{total[i]}</Decimal>,

--- a/web/src/containers/ToolBar/MarketSelector/MarketsList/index.tsx
+++ b/web/src/containers/ToolBar/MarketSelector/MarketsList/index.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
+import { DEFAULT_PERCENTAGE_PRECISION } from 'src/constants';
 import { IntlProps } from '../../../../';
 import { incrementalOrderBook } from '../../../../api';
 import { SortAsc, SortDefault, SortDesc } from '../../../../assets/images/SortIcons';
@@ -190,7 +191,11 @@ class MarketsListComponent extends React.Component<Props, State> {
                 market.name,
                 (<span className={classname}>{Decimal.format(Number(market.last), market.price_precision, ',')}</span>),
                 (<span className={classname}>{Decimal.format(Number(market.volume), market.price_precision, ',')}</span>),
-                (<span className={classname}>{market.price_change_percent}</span>),
+                (<span className={classname}>
+                    {market.price_change_percent?.charAt(0)}
+                    {Decimal.format(market.price_change_percent?.slice(1, -1), DEFAULT_PERCENTAGE_PRECISION, ',')}
+                    %
+                </span>),
             ];
         });
     }

--- a/web/src/mobile/components/CurrentMarketInfo/index.tsx
+++ b/web/src/mobile/components/CurrentMarketInfo/index.tsx
@@ -4,7 +4,7 @@ import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import { CloseIcon } from '../../../assets/images/CloseIcon';
 import { Decimal, FilterInput } from '../../../components';
-import { DEFAULT_CCY_PRECISION } from '../../../constants';
+import { DEFAULT_CCY_PRECISION, DEFAULT_PERCENTAGE_PRECISION } from '../../../constants';
 import { MarketsTable } from '../../../containers';
 import { Market, selectCurrentMarket, selectMarkets, selectMarketTickers } from '../../../modules';
 import { ChevronIcon } from '../../assets/images/ChevronIcon';
@@ -83,7 +83,11 @@ const CurrentMarketInfoComponent: React.FC = () => {
                     <span className={currentMarketChangeClass}>
                         {Decimal.format(currentMarketTicker.last, currentMarketPricePrecision, ',')}
                     </span>
-                    <span className={currentMarketChangeClass}>{currentMarketTicker.price_change_percent}</span>
+                    <span className={currentMarketChangeClass}>
+                        {currentMarketTicker.price_change_percent?.charAt(0)}
+                        {Decimal.format(currentMarketTicker.price_change_percent?.slice(1, -1), DEFAULT_PERCENTAGE_PRECISION, ',')}
+                        %
+                    </span>
                 </div>
             </div>
             <div className="pg-mobile-current-market-info__right">

--- a/web/src/mobile/components/EstimatedValue/index.tsx
+++ b/web/src/mobile/components/EstimatedValue/index.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
-import { VALUATION_PRIMARY_CURRENCY, VALUATION_SECONDARY_CURRENCY } from '../../../constants';
+import { Decimal } from 'src/components';
+import { handleCCYPrecision } from 'src/helpers';
+import { DEFAULT_CCY_PRECISION, VALUATION_PRIMARY_CURRENCY, VALUATION_SECONDARY_CURRENCY } from '../../../constants';
 import { estimateUnitValue, estimateValue } from '../../../helpers/estimateValue';
 import { useCurrenciesFetch, useMarketsFetch, useMarketsTickersFetch, useWalletsFetch } from '../../../hooks';
 import { selectCurrencies, selectMarkets, selectMarketTickers, selectWallets } from '../../../modules';
@@ -14,6 +16,8 @@ const EstimatedValueMobile = React.memo(() => {
     const tickers = useSelector(selectMarketTickers);
     const estimatedValue = estimateValue(VALUATION_PRIMARY_CURRENCY, currencies, wallets, markets, tickers);
     const estimatedSecondaryValue = estimateUnitValue(VALUATION_SECONDARY_CURRENCY, VALUATION_PRIMARY_CURRENCY, +estimatedValue, currencies, markets, tickers);
+    const estimatedPrecision = handleCCYPrecision(currencies, VALUATION_PRIMARY_CURRENCY.toLowerCase(), DEFAULT_CCY_PRECISION);
+    const estimatedSecondaryPrecision = handleCCYPrecision(currencies, VALUATION_SECONDARY_CURRENCY.toLowerCase(), DEFAULT_CCY_PRECISION);
 
     useWalletsFetch();
     useMarketsFetch();
@@ -27,11 +31,11 @@ const EstimatedValueMobile = React.memo(() => {
             </div>
             <div className="cr-mobile-wallets-banner__body">
                 <div className="cr-mobile-wallets-banner__body-wrap">
-                    <span className="cr-mobile-wallets-banner__body-number">{estimatedValue}</span>
+                    <span className="cr-mobile-wallets-banner__body-number">{Decimal.format(estimatedValue, estimatedPrecision, ',')}</span>
                     <span className="cr-mobile-wallets-banner__body-currency">{VALUATION_PRIMARY_CURRENCY.toUpperCase()}</span>
                 </div>
                 <div className="cr-mobile-wallets-banner__body-wrap">
-                    <span className="cr-mobile-wallets-banner__body-number">{estimatedSecondaryValue}</span>
+                    <span className="cr-mobile-wallets-banner__body-number">{Decimal.format(estimatedSecondaryValue, estimatedSecondaryPrecision, ',')}</span>
                     <span className="cr-mobile-wallets-banner__body-currency">{VALUATION_SECONDARY_CURRENCY.toUpperCase()}</span>
                 </div>
             </div>

--- a/web/src/mobile/components/HistoryTable/Rowitem.tsx
+++ b/web/src/mobile/components/HistoryTable/Rowitem.tsx
@@ -7,7 +7,7 @@ const RowItemComponent = props => {
         <div className="cr-mobile-table-row">
             <div className="cr-mobile-table-row__amount">
                 <div className="cr-mobile-table-row__amount-value">
-                    <Decimal fixed={props.fixed}>{props.amount}</Decimal>
+                    <Decimal fixed={props.fixed} thousSep=",">{props.amount}</Decimal>
                 </div>
                 <span className="cr-mobile-table-row__amount-currency">{props.currency}</span>
             </div>

--- a/web/src/mobile/components/OpenOrders/index.tsx
+++ b/web/src/mobile/components/OpenOrders/index.tsx
@@ -19,7 +19,7 @@ const OpenOrdersComponent: React.FC = () => {
     const shouldFetchCancelAll = useSelector(selectShouldFetchCancelAll);
     const shouldFetchCancelSingle = useSelector(selectShouldFetchCancelSingle);
     useUserOrdersHistoryFetch(0, 'open', 25);
-    const waitOrders = orders.filter(o => ['wait', 'pending'].includes(o.state));
+    const waitOrders = orders.filter(o => ['wait', 'trigger_wait'].includes(o.state));
 
     const handleCancelAllOrders = () => {
         if (shouldFetchCancelAll) {

--- a/web/src/mobile/components/Orders/OrdersItem.tsx
+++ b/web/src/mobile/components/Orders/OrdersItem.tsx
@@ -17,7 +17,10 @@ const OrdersItemComponent = props => {
             return '';
         }
 
-        return intl.formatMessage({ id: `page.mobile.orders.header.orderType.${side}.${type}` });
+        const isCommonType = ['stop_loss', 'stop_limit', 'take_limit', 'take_profit'].includes(type);
+        const id = `page.mobile.orders.header.orderType.` + (isCommonType ? type : `${side}.${type}`);
+        
+        return intl.formatMessage({ id });
     };
 
     const currentMarket = (markets.length && markets.find(m => m.id === order.market)) ||
@@ -61,13 +64,13 @@ const OrdersItemComponent = props => {
                     <div>
                         <span>{intl.formatMessage({ id: 'page.mobile.orders.header.amount' })}</span>
                         <span className="pg-mobile-orders-item__row__block__value">
-                            <Decimal fixed={currentMarket.amount_precision}>{order.remaining_volume}</Decimal>
+                            <Decimal fixed={currentMarket.amount_precision} thousSep=",">{order.remaining_volume}</Decimal>
                         </span>
                     </div>
                     <div className="pg-mobile-orders-item__second__row">
                         <span>{intl.formatMessage({ id: 'page.mobile.orders.header.volume' })}</span>
                         <span className="pg-mobile-orders-item__row__block__value">
-                            <Decimal fixed={currentMarket.price_precision}>{+order.remaining_volume  * +order.price}</Decimal>
+                            <Decimal fixed={currentMarket.price_precision} thousSep=",">{+order.remaining_volume  * +order.price}</Decimal>
                         </span>
                     </div>
                 </div>
@@ -75,7 +78,7 @@ const OrdersItemComponent = props => {
                     <div>
                         <span>{intl.formatMessage({ id: 'page.mobile.orders.header.price' })}</span>
                         <span className="pg-mobile-orders-item__row__block__value">
-                            <Decimal fixed={currentMarket.price_precision}>{actualPrice}</Decimal>
+                            <Decimal fixed={currentMarket.price_precision} thousSep=",">{actualPrice}</Decimal>
                         </span>
                     </div>
                     <div className="pg-mobile-orders-item__second__row">
@@ -83,7 +86,7 @@ const OrdersItemComponent = props => {
                         <span className="pg-mobile-orders-item__row__block__value">
                             {
                                 order.trigger_price ?
-                                    <Decimal fixed={currentMarket.price_precision}>{order.trigger_price}</Decimal> :
+                                    <Decimal fixed={currentMarket.price_precision} thousSep=",">{order.trigger_price}</Decimal> :
                                     '-'
                             }
                         </span>

--- a/web/src/mobile/components/Orders/index.tsx
+++ b/web/src/mobile/components/Orders/index.tsx
@@ -34,7 +34,7 @@ const OrdersComponent: React.FC<IOrdersComponentProps> = ({ withDropdownSelect }
     const firstElemIndex = useSelector((state: RootState) => selectOrdersFirstElemIndex(state, 25));
     const lastElemIndex = useSelector((state: RootState) => selectOrdersLastElemIndex(state, 25));
     const ordersNextPageExists = useSelector(selectOrdersNextPageExists);
-    const filteredOrders = currentTabIndex === 0 ? orders.filter(o => ['wait', 'pending'].includes(o.state)) : orders;
+    const filteredOrders = currentTabIndex === 0 ? orders.filter(o => ['wait', 'trigger_wait'].includes(o.state)) : orders;
     useUserOrdersHistoryFetch(currentPageIndex, userOrdersHistoryTabs[currentTabIndex], 25);
     useMarketsFetch();
 

--- a/web/src/mobile/components/WalletBanner/index.tsx
+++ b/web/src/mobile/components/WalletBanner/index.tsx
@@ -24,14 +24,14 @@ const WalletBannerComponent = (props: Props) => {
             <div className="cr-wallet-banner-mobile__item">
                 <span className="cr-wallet-banner-mobile__item-title">{intl.formatMessage({ id: 'page.mobile.wallets.banner.total' })}</span>
                 <div className="cr-wallet-banner-mobile__item-info">
-                    <Decimal fixed={fixed} children={+(balance || 0) + +(locked || 0)}/>
+                    <Decimal fixed={fixed} children={+(balance || 0) + +(locked || 0)} thousSep=","/>
                     <span className="cr-wallet-banner-mobile__item-info-currency">{currency}</span>
                 </div>
             </div>
             <div className="cr-wallet-banner-mobile__item">
                 <span className="cr-wallet-banner-mobile__item-title">{intl.formatMessage({ id: 'page.mobile.wallets.banner.available' })}</span>
                 <div className="cr-wallet-banner-mobile__item-info">
-                    <Decimal fixed={fixed} children={balance || 0}/>
+                    <Decimal fixed={fixed} children={balance || 0} thousSep=","/>
                     <span className="cr-wallet-banner-mobile__item-info-currency">{currency}</span>
                 </div>
             </div>

--- a/web/src/mobile/components/WalletItem/index.tsx
+++ b/web/src/mobile/components/WalletItem/index.tsx
@@ -27,7 +27,7 @@ const WalletItemComponent = (props: Props) => {
                 <span className="cr-mobile-wallet-item__name">{name}</span>
             </div>
             <div className="cr-mobile-wallet-item__balance">
-                <span><Decimal fixed={fixed} children={balance || 0}/></span>
+                <span><Decimal fixed={fixed} children={balance || 0} thousSep=","/></span>
             </div>
         </div>
     );

--- a/web/src/mobile/styles/components/CreateOrder.pcss
+++ b/web/src/mobile/styles/components/CreateOrder.pcss
@@ -102,6 +102,7 @@
           justify-content: space-between;
           padding: 0;
           width: 100%;
+          height: max-content;
 
           th {
             align-items: flex-start;
@@ -175,6 +176,14 @@
       }
 
       &:first-child {
+        .cr-table {
+          display: flex;
+          flex-direction: column;
+          height: 100%;
+          justify-content: flex-end;
+          overflow: visible;
+        }
+
         tbody::before {
           height: 0;
         }


### PR DESCRIPTION
* Fix: fix markup on orders

* Fix: styles due new mockup

* Fix: displaying values

* Fix: remove parseFloat in decimal component content

* removed unused constant

* Fix: translations and thousands seperator of open orders

* Fix: mobile orders, order book, thousand separator

* Fix: review comments

* Fix: Decimal component usage

Co-authored-by: Gabriel-1021 <gabriel.montoya1021@gmail.com>
Co-authored-by: josadcha <josadcha@heliostech.fr>