### PR TITLE
Fix: clear only 2fa input when create beneficiary failed

### DIFF
--- a/web/src/components/Beneficiaries/BeneficiariesAddModal.tsx
+++ b/web/src/components/Beneficiaries/BeneficiariesAddModal.tsx
@@ -140,7 +140,6 @@ const BeneficiariesAddModalComponent: React.FC<Props> = (props: Props) => {
         };
 
         dispatch(beneficiariesCreate(payload));
-        handleClearModalsInputs();
     }, [coinAddress, coinBeneficiaryName, coinDescription, currency, coinBlockchainName, coinDestinationTag, code2FA]);
 
     const getState = React.useCallback(key => {


### PR DESCRIPTION
[Jira Ticket](https://openware-inc.atlassian.net/browse/OPD-1072)

Clear only 2fa input when create beneficiary failed.